### PR TITLE
Task 1 bugfix

### DIFF
--- a/src/components/launch.js
+++ b/src/components/launch.js
@@ -18,6 +18,7 @@ import {
   Stack,
   AspectRatio,
   StatGroup,
+  Tooltip,
 } from "@chakra-ui/react";
 
 import { useSpaceXQuery } from "../utils/use-space-x";
@@ -128,9 +129,11 @@ function TimeAndLocation({ launch }) {
             Launch Date
           </Box>
         </StatLabel>
+        <Tooltip label={formatDateTime(launch.date_local)}>
         <StatNumber fontSize={["md", "xl"]}>
-          {formatDateTime(launch.date_local)}
+          {formatDateTime(launch.date_local, launch.launchpad.timezone)}
         </StatNumber>
+        </Tooltip>
         <StatHelpText>{timeAgo(launch.date_utc)}</StatHelpText>
       </Stat>
       <Stat>

--- a/src/utils/format-date.js
+++ b/src/utils/format-date.js
@@ -1,13 +1,26 @@
-export function formatDate(timestamp) {
+/**
+ * Formats a date for displaying it.
+ * @param {string | number | Date } timestamp value to format, in a format that is accepted by the Date constructor.
+ * @param {string} [timeZone] {@link https://www.iana.org/time-zones IANA} name of timezone used for displaying. Machine default timezone is used when not set.
+ * @returns {string} the formatted date string
+ */
+export function formatDate(timestamp, timeZone) {
   return new Intl.DateTimeFormat("en-US", {
     weekday: "long",
     year: "numeric",
     month: "long",
     day: "numeric",
+    timeZone,
   }).format(new Date(timestamp));
 }
 
-export function formatDateTime(timestamp) {
+/**
+ * Formats a date and time for displaying it.
+ * @param {string | number | Date } timestamp value to format, in a format that is accepted by the Date constructor.
+ * @param {string} [timeZone] {@link https://www.iana.org/time-zones IANA} name of timezone used for displaying. Machine default timezone is used when not set.
+ * @returns {string} the formatted date string
+ */
+export function formatDateTime(timestamp, timeZone) {
   return new Intl.DateTimeFormat("en-US", {
     year: "numeric",
     month: "long",
@@ -16,5 +29,6 @@ export function formatDateTime(timestamp) {
     minute: "numeric",
     second: "numeric",
     timeZoneName: "short",
+    timeZone,
   }).format(new Date(timestamp));
 }

--- a/src/utils/format-date.test.js
+++ b/src/utils/format-date.test.js
@@ -1,0 +1,24 @@
+import { formatDate, formatDateTime } from "./format-date";
+
+test("Date formatting respects local time zone if given", async () => {
+  const formattedDate = formatDate(
+    "2022-07-23T23:00:00-04:00",
+    "America/New_York"
+  );
+
+  expect(formattedDate).toEqual("Saturday, July 23, 2022");
+});
+
+test("Datetime formatting respects local time zone if given", async () => {
+  const formattedDate = formatDateTime(
+    "2022-03-22T23:00:00-04:00",
+    "America/New_York"
+  );
+
+  expect(formattedDate).toEqual("March 22, 2022 at 11:00:00 PM EDT");
+});
+
+// Testing the opposite case of using the local timezone of the machine
+// in case no timezone is provided is hard to test in a way that would
+// not introduce flakyness depending on machine settings. The additional
+// complexity of this would likely cause more harm than it prevents.


### PR DESCRIPTION
As discussed, adjusted the display of launch times to use the local time of the launch pad instead of the local time of the user.

- Extended formatting utility to allow for providing intended timezone for display
- Adjusted formatting & added tooltip